### PR TITLE
Fix mvn clean command for powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Smoke Tests require server running on port 8080 by default.
 ## Build WAR ignoring Smoke Tests
 
 ```
-$ mvn clean package -DskipTests -Dmaven.test.skip=true
+$ mvn clean package -DskipTests -D "maven.test.skip=true"
 ```
 
 ## Run Smoke Tests against specific URL


### PR DESCRIPTION
Arg parsing is done differently and token is split at the period resulting in error:
`[ERROR] Unknown lifecycle phase ".test.skip=true". You must specify a valid lifecycle phase or a goal in the format <plugin-prefix>:<goal> or <plugin-group-id>:<plugin-artifact-id>[:<plugin-version>]:<goal>.`